### PR TITLE
Add backoff logic to amazon communications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='tap-s3-csv',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_s3_csv'],
       install_requires=[
+          'backoff==1.3.2',
           'boto3==1.4.4',
           'singer-encodings==0.0.3',
           'singer-python==5.1.5',

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -1,10 +1,10 @@
 import json
 import sys
-import boto3
 import singer
 
 from singer import metadata
 from tap_s3_csv.discover import discover_streams
+from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
 from tap_s3_csv.config import CONFIG_CONTRACT
 
@@ -12,12 +12,6 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ["start_date", "bucket", "account_id", "external_id", "role_name"]
 
-def setup_aws_client(config):
-    client = boto3.client('sts')
-    role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'], config['role_name'])
-
-    role = client.assume_role(RoleArn=role_arn, ExternalId=config['external_id'], RoleSessionName='TapS3CSV')
-    boto3.setup_default_session(aws_access_key_id=role['Credentials']['AccessKeyId'], aws_secret_access_key=role['Credentials']['SecretAccessKey'], aws_session_token=role['Credentials']['SessionToken'])
 
 def do_discover(config):
     LOGGER.info("Starting discover")
@@ -79,7 +73,7 @@ def main():
 
     config['tables'] = validate_table_config(config)
 
-    setup_aws_client(config)
+    s3.setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -1,5 +1,7 @@
 import re
+import backoff
 import boto3
+import botocore
 import singer
 
 from singer_encodings import csv
@@ -10,6 +12,23 @@ LOGGER = singer.get_logger()
 SDC_SOURCE_BUCKET_COLUMN = "_sdc_source_bucket"
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"
 SDC_SOURCE_LINENO_COLUMN = "_sdc_source_lineno"
+
+
+def log_backoff_attempt(details):
+    LOGGER.info("Error detected communicating with Amazon, triggering backoff: %d try", details.get("tries"))
+
+@backoff.on_exception(backoff.expo,
+                      botocore.exceptions.ClientError,
+                      max_tries=5,
+                      on_backoff=log_backoff_attempt,
+                      factor=2)
+def setup_aws_client(config):
+    client = boto3.client('sts')
+    role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'], config['role_name'])
+
+    role = client.assume_role(RoleArn=role_arn, ExternalId=config['external_id'], RoleSessionName='TapS3CSV')
+    boto3.setup_default_session(aws_access_key_id=role['Credentials']['AccessKeyId'], aws_secret_access_key=role['Credentials']['SecretAccessKey'], aws_session_token=role['Credentials']['SessionToken'])
+
 
 def get_sampled_schema_for_table(config, table_spec):
     LOGGER.info('Sampling records to determine table schema.')
@@ -132,7 +151,11 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
 
     return to_return
 
-
+@backoff.on_exception(backoff.expo,
+                      botocore.exceptions.ClientError,
+                      max_tries=5,
+                      on_backoff=log_backoff_attempt,
+                      factor=2)
 def list_files_in_bucket(bucket, search_prefix=None):
     s3_client = boto3.client('s3')
 
@@ -172,7 +195,11 @@ def list_files_in_bucket(bucket, search_prefix=None):
 
     return s3_objects
 
-
+@backoff.on_exception(backoff.expo,
+                      botocore.exceptions.ClientError,
+                      max_tries=5,
+                      on_backoff=log_backoff_attempt,
+                      factor=2)
 def get_file_handle(config, s3_path):
     bucket = config['bucket']
     s3_client = boto3.resource('s3')


### PR DESCRIPTION
The most frequent error case is when Amazon hasn't propagated whatever it needs to propagate when Policies / Roles are created. Add backoff code to retry a few times before we officially fail.