### PR TITLE
Fix/config parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-s3-csv/bin/activate
             pip install .
             pip install pylint
-            pylint tap_s3_csv -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,broad-except
+            pylint tap_s3_csv -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,broad-except,bare-except,unused-variable,unnecessary-comprehension,no-member,deprecated-method
       - run:
           name: 'Unit Tests'
           command: |

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -53,6 +53,8 @@ def validate_table_config(config):
     tables_config = json.loads(config['tables'])
 
     for table_config in tables_config:
+        if table_config.get('search_prefix') is None:
+            table_config.pop('search_prefix')
         if table_config.get('key_properties') == "" or table_config.get('key_properties') is None:
             table_config['key_properties'] = []
         elif table_config.get('key_properties'):

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -57,12 +57,11 @@ def validate_table_config(config):
             table_config.pop('search_prefix')
         if table_config.get('key_properties') == "" or table_config.get('key_properties') is None:
             table_config['key_properties'] = []
-        elif table_config.get('key_properties'):
+        elif table_config.get('key_properties') and isinstance(table_config['key_properties'], str):
             table_config['key_properties'] = [s.strip() for s in table_config['key_properties'].split(',')]
-
         if table_config.get('date_overrides') == "" or table_config.get('date_overrides') is None:
             table_config['date_overrides'] = []
-        elif table_config.get('date_overrides'):
+        elif table_config.get('date_overrides') and isinstance(table_config['date_overrides'], str):
             table_config['date_overrides'] = [s.strip() for s in table_config['date_overrides'].split(',')]
 
     # Reassign the config tables to the validated object

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -193,7 +193,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
 
         if (unmatched_files_count + matched_files_count) % max_files_before_log == 0:
             # Are we skipping greater than 50% of the files?
-            if 0.5 < (unmatched_files_count / (matched_files_count + unmatched_files_count)):
+            if (unmatched_files_count / (matched_files_count + unmatched_files_count)) > 0.5:
                 LOGGER.warn(("Found %s matching files and %s non-matching files. "
                              "You should consider adding a `search_prefix` to the config "
                              "or removing non-matching files from the bucket."),
@@ -202,7 +202,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
                 LOGGER.info("Found %s matching files and %s non-matching files",
                             matched_files_count, unmatched_files_count)
 
-    if 0 == matched_files_count:
+    if matched_files_count == 0:
         raise Exception("No files found matching pattern {}".format(pattern))
 
 
@@ -229,7 +229,7 @@ def list_files_in_bucket(bucket, search_prefix=None):
         s3_object_count += len(page['Contents'])
         yield from page['Contents']
 
-    if 0 < s3_object_count:
+    if s3_object_count > 0:
         LOGGER.info("Found %s files.", s3_object_count)
     else:
         LOGGER.warning('Found no files for bucket "%s" that match prefix "%s"', bucket, search_prefix)


### PR DESCRIPTION
# Description of change
Due to a recent change in the UI, `key_properties` and `date_overrides` are now being passed as lists instead of strings and `search_prefix` can now come through as None.

This PR changes the tap to handle both lists and strings for `key_properties` and `date_overrides` and to handle None for `search_prefix`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
