### PR TITLE
version bump to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+  * Adds support for Compressed files [#32](https://github.com/singer-io/tap-s3-csv/pull/32)
+  * Adds support for JSONL files [#31](https://github.com/singer-io/tap-s3-csv/pull/31)
+  * Adds support for duplicated headers in CSV files [#30](https://github.com/singer-io/tap-s3-csv/pull/30)
+  * Adds testing [#29](https://github.com/singer-io/tap-s3-csv/pull/29)
+  * Updates `backoff`, `singer-encodings`, and `singer-python` dependencies
+  * Updates logging messages
+
 ## 1.2.3
   * Fix issue relating to search_prefix config values
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.2.3',
+      version='1.3.0',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
## 1.3.0
  * Adds support for Compressed files [#32](https://github.com/singer-io/tap-s3-csv/pull/32)
  * Adds support for JSONL files [#31](https://github.com/singer-io/tap-s3-csv/pull/31)
  * Adds support for duplicated headers in CSV files [#30](https://github.com/singer-io/tap-s3-csv/pull/30)
  * Adds testing [#29](https://github.com/singer-io/tap-s3-csv/pull/29)
  * Updates `backoff`, `singer-encodings`, and `singer-python` dependencies
  * Updates logging messages

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
