### PR TITLE
Strictly enforce the ordering of type checking for integer vs number

### DIFF
--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -7,9 +7,6 @@ def infer(key, datum, date_overrides, check_second_call=False):
     """
     Returns the inferred data type
     """
-
-    data_type_list = {int: 'integer', float: 'number'}
-
     if datum is None or datum == '':
         return None
 
@@ -32,12 +29,16 @@ def infer(key, datum, date_overrides, check_second_call=False):
         if isinstance(datum, dict):
             return 'dict'
 
-        for datatype in data_type_list:
-            try:
-                datatype(str(datum))
-                return data_type_list[datatype]
-            except (ValueError, TypeError):
-                pass
+        try:
+            int(str(datum))
+            return 'integer'
+        except (ValueError, TypeError):
+            pass
+        try:
+            float(str(datum))
+            return 'integer'
+        except (ValueError, TypeError):
+            pass
 
     except (ValueError, TypeError):
         pass

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -2,7 +2,7 @@ import singer
 
 LOGGER = singer.get_logger()
 
-
+#pylint: disable=too-many-return-statements
 def infer(key, datum, date_overrides, check_second_call=False):
     """
     Returns the inferred data type

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -36,7 +36,7 @@ def infer(key, datum, date_overrides, check_second_call=False):
             pass
         try:
             float(str(datum))
-            return 'integer'
+            return 'number'
         except (ValueError, TypeError):
             pass
 


### PR DESCRIPTION
# Description of change
Strictly enforce the ordering of type checking for integer vs number. Differences in python versions can cause differences in the ordering of maps, relying on the ordering of maps is unreliable. The map was causing `float` to take precedence over `integer` in certain python versions.

# Manual QA steps
 - Ran the tap many times. Without this change and running python 3.5.2 caused the `float` to come first in the iteration over the map, while running it in python 3.8.0 had `int` come first. With this change it is consistent ordering across python versions.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
