### PR TITLE
Bump to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+  * Fixed bug that caused `integer`s to be discovered as `number` differently in different versions of python [#35](https://github.com/singer-io/tap-s3-csv/pull/35)
+
 ## 1.3.0
   * Adds support for Compressed files [#32](https://github.com/singer-io/tap-s3-csv/pull/32)
   * Adds support for JSONL files [#31](https://github.com/singer-io/tap-s3-csv/pull/31)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
* Bump to v1.3.1
* Fixed bug that caused `integer`s to be discovered as `number` differently in different versions of python #35

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
