### PR TITLE
Bump to v1.3.2, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.2
   * Skip files without a name [#37](https://github.com/singer-io/tap-s3-csv/pull/37)
+  * Fix an issue to allow the tap to run with a catalog without schemas [#38](https://github.com/singer-io/tap-s3-csv/pull/38)
 
 ## 1.3.1
   * Fixed bug that caused `integer`s to be discovered as `number` differently in different versions of python [#35](https://github.com/singer-io/tap-s3-csv/pull/35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.2
+  * Skip files without a name [#37](https://github.com/singer-io/tap-s3-csv/pull/37)
+
 ## 1.3.1
   * Fixed bug that caused `integer`s to be discovered as `number` differently in different versions of python [#35](https://github.com/singer-io/tap-s3-csv/pull/35)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.1',
+      version='1.3.2',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
This is the version bump for #37 and #38

## 1.3.2
  * Skip files without a name [#37](https://github.com/singer-io/tap-s3-csv/pull/37)
  * Fix an issue to allow the tap to run with a catalog without schemas [#38](https://github.com/singer-io/tap-s3-csv/pull/38)
 
# Manual QA steps
 - See #37 and #38
 
# Risks
 - See #37 and #38
 
# Rollback steps
 - revert #37 and/or #38 and bump the version
