### PR TITLE
Bump csv field width

### DIFF
--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -148,7 +148,7 @@ def maximize_csv_field_width():
                 csv.csv.field_size_limit(field_size_limit)
                 break
             except OverflowError:
-                field_size_lifield_size_limitmit = int(field_size_limit / 10)
+                field_size_limit = int(field_size_limit / 10)
 
         LOGGER.info(f"Changed the CSV field size limit from {current_field_size_limit} to {field_size_limit}")
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -141,7 +141,9 @@ def maximize_csv_field_width():
 
     if current_field_size_limit != field_size_limit:
         csv.csv.field_size_limit(field_size_limit)
-        LOGGER.info(f"Changed the CSV field size limit from {current_field_size_limit} to {field_size_limit}")
+        LOGGER.info("Changed the CSV field size limit from %s to %s",
+                    current_field_size_limit,
+                    field_size_limit)
 
 def get_records_for_csv(s3_path, sample_rate, iterator):
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -140,16 +140,7 @@ def maximize_csv_field_width():
     field_size_limit = sys.maxsize
 
     if current_field_size_limit != field_size_limit:
-        # Credit: https://til.simonwillison.net/python/csv-error-column-too-large
-        while True:
-            try:
-                if field_size_limit < current_field_size_limit:
-                    break
-                csv.csv.field_size_limit(field_size_limit)
-                break
-            except OverflowError:
-                field_size_limit = int(field_size_limit / 10)
-
+        csv.csv.field_size_limit(field_size_limit)
         LOGGER.info(f"Changed the CSV field size limit from {current_field_size_limit} to {field_size_limit}")
 
 def get_records_for_csv(s3_path, sample_rate, iterator):


### PR DESCRIPTION
# Description of change
This PR increases the limit on the width of a field in the CSV files we read in the tap.

Here is a simple proof of concept script

```sh
$ cat foo.csv
id,value
1,abcdefghij
```

```python
$ python3
Python 3.8.10 (default, Jun  1 2021, 15:06:54)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import csv

# Set our limit to 10
>>> csv.field_size_limit(10)
131072

# Check that it gets set
>>> csv.field_size_limit()
10

# Read and print the file
>>> with open('foo.csv') as csv_file:
...   csv_reader = csv.reader(csv_file, delimiter=',')
...   for row in csv_reader:
...     print(row)
...
['id', 'value']
['1', 'abcdefghij']

# Set the limit to 9, one character short of the biggest field in our file
>>> csv.field_size_limit(9)
10

# Check that the limit was set
>>> csv.field_size_limit()
9

# Try to read again and watch it fail with the same error as the tap
>>> with open('foo.csv') as csv_file:
...   csv_reader = csv.reader(csv_file, delimiter=',')
...   for row in csv_reader:
...     print(row)
...
['id', 'value']
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
_csv.Error: field larger than field limit (9)
```


# Manual QA steps
 - I ran the tap
 
# Risks
 - This will likely obscure any future `_csv.Error: field larger than field limit` errors with an OOM error.
 
# Rollback steps
 - revert this branch and bump the version
