### PR TITLE
Version bump to `v1.3.5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-##1.3.4
- * Bump singer-encodings to 0.1.2 [21](https://github.com/singer-io/singer-encodings/pull/21)
+## 1.3.4
+  * Bump singer-encodings to 0.1.2 [#21](https://github.com/singer-io/singer-encodings/pull/21)
 
 ## 1.3.3
   * Bump singer-encodings to 0.1.1 [#41](https://github.com/singer-io/tap-s3-csv/pull/41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.5
+  * Increase the limit on the width of a field in the CSV files read by the tap [#47](https://github.com/singer-io/singer-encodings/pull/47)
+
 ## 1.3.4
   * Bump singer-encodings to 0.1.2 [#21](https://github.com/singer-io/singer-encodings/pull/21)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.4',
+      version='1.3.5',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
This is the version bump for #47 

# Manual QA steps
 - See #47 
 
# Risks
 - See #47 
 
# Rollback steps
 - revert #47 and bump the version
