### PR TITLE
TDL-20459, TDL-21606: Remove backoff for Access Denied error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-s3-csv/bin/activate
-            pip install nose coverage
+            pip install nose coverage parameterized
             nosetests --with-coverage --cover-erase --cover-package=tap_s3_csv --cover-html-dir=htmlcov tests/unittests
             coverage html
       - store_test_results:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.3.7
   * Remove Backoff for Access Denied errors
-  * Only assume role from config and test bucket accessiblity
   * Add unitttest for access denied giveup
   * [#55](https://github.com/singer-io/tap-s3-csv/pull/55)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.7
+  * Remove Backoff for Access Denied errors
+  * Only assume role from config and test bucket accessiblity
+  * Add unitttest for access denied giveup
+  * [#55](https://github.com/singer-io/tap-s3-csv/pull/55)
+
 ## 1.3.6
   *  Implement request timeout [#46](https://github.com/singer-io/singer-encodings/pull/46)
   *  Updgrade SDK version [#51](https://github.com/singer-io/singer-encodings/pull/51)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.6',
+      version='1.3.7',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',
@@ -18,7 +18,7 @@ setup(name='tap-s3-csv',
       ],
       extras_require={
           'dev': [
-              'ipdb==0.11'
+              'ipdb'
           ]
       },
       entry_points='''

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -74,12 +74,7 @@ def main():
 
     config['tables'] = validate_table_config(config)
 
-    try:
-        for page in s3.list_files_in_bucket(config):
-            break
-        LOGGER.warning("I have direct access to the bucket without assuming the configured role.")
-    except:
-        s3.setup_aws_client(config)
+    s3.setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -74,7 +74,12 @@ def main():
 
     config['tables'] = validate_table_config(config)
 
-    s3.setup_aws_client(config)
+    try:
+        for page in s3.list_files_in_bucket(config):
+            break
+        LOGGER.warning("I have direct access to the bucket without assuming the configured role.")
+    except:
+        s3.setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -46,7 +46,7 @@ def is_access_denied_error(error):
         and return boolean values accordingly, to decide whether to backoff or not.
     """
     # retry if the error string contains 'Access Denied'
-    if 'Access Denied' in str(error):
+    if 'Access Denied' in str(error) or 'AccessDenied' in str(error):
         return True
     return False
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -46,7 +46,7 @@ def is_access_denied_error(error):
         and return boolean values accordingly, to decide whether to backoff or not.
     """
     # retry if the error string contains 'Access Denied'
-    if str(error).__contains__('Access Denied'):
+    if 'Access Denied' in str(error):
         return True
     return False
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -40,6 +40,16 @@ skipped_files_count = 0
 # timeout request after 300 seconds
 REQUEST_TIMEOUT = 300
 
+def is_access_denied_error(error):
+    """
+        This function checks whether the URLError contains 'Access Denied' substring
+        and return boolean values accordingly, to decide whether to backoff or not.
+    """
+    # retry if the error string contains 'Access Denied'
+    if str(error).__contains__('Access Denied'):
+        return True
+    return False
+
 def retry_pattern(fnc):
     @backoff.on_exception(backoff.expo,
                           (ConnectTimeoutError, ReadTimeoutError),
@@ -50,6 +60,7 @@ def retry_pattern(fnc):
                           ClientError,
                           max_tries=5,
                           on_backoff=log_backoff_attempt,
+                          giveup=is_access_denied_error, # Giveup if we do not have the access
                           factor=10)
     @functools.wraps(fnc)
     def wrapper(*args, **kwargs):
@@ -419,7 +430,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
         raise ValueError(
             ("search_pattern for table `{}` is not a valid regular "
              "expression. See "
-             "https://docs.python.org/3.5/library/re.html#regular-expression-syntax").format(table_spec['table_name']),
+             "https://docs.python.org/3.9/library/re.html").format(table_spec['table_name']),
             pattern) from e
 
     LOGGER.info(

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -430,7 +430,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
         raise ValueError(
             ("search_pattern for table `{}` is not a valid regular "
              "expression. See "
-             "https://docs.python.org/3.9/library/re.html").format(table_spec['table_name']),
+             "https://docs.python.org/3.9/library/re.html#regular-expression-syntax").format(table_spec['table_name']),
             pattern) from e
 
     LOGGER.info(

--- a/tests/unittests/test_giveup_for_access_denied_error.py
+++ b/tests/unittests/test_giveup_for_access_denied_error.py
@@ -8,6 +8,8 @@ def get(*args, **kwargs):
     """Function to raise an appropriate error as per the arguments"""
     if kwargs.get("access_denied_error"):
         raise ClientError({"Error": {"Message": "Access Denied", "Code": "AccessDenied"}}, "ListObjectsV2")
+    elif kwargs.get("AccessDenied_error"):
+        raise ClientError({"Error": {"Message": "You arr not authorized to perform this action", "Code": "AccessDenied"}}, "ListObjectsV2")
     else:
         raise ClientError({"Error": {"Message": "Test Error", "Code": "TestError"}}, "ListObjectsV2")
 
@@ -16,6 +18,7 @@ class TestGiveUpForAccessDeniedError(unittest.TestCase):
 
     @parameterized.expand([
         ["giveup_for_access_denied_error", {"access_denied_error": True}, 1],
+        ["giveup_for_AccessDenied_error", {"AccessDenied_error": True}, 1],
         ["not_giveup", {}, 5],
     ])
     @mock.patch("time.sleep")

--- a/tests/unittests/test_giveup_for_access_denied_error.py
+++ b/tests/unittests/test_giveup_for_access_denied_error.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest import mock
+from tap_s3_csv.s3 import PageIterator
+from botocore.exceptions import ClientError
+from parameterized import parameterized
+
+def get(*args, **kwargs):
+    """Function to raise an appropriate error as per the arguments"""
+    if kwargs.get("access_denied_error"):
+        raise ClientError({"Error": {"Message": "Access Denied", "Code": "AccessDenied"}}, "ListObjectsV2")
+    else:
+        raise ClientError({"Error": {"Message": "Test Error", "Code": "TestError"}}, "ListObjectsV2")
+
+class TestGiveUpForAccessDeniedError(unittest.TestCase):
+    """Test case to verify we giveup when we encounter Access Denied error"""
+
+    @parameterized.expand([
+        ["giveup_for_access_denied_error", {"access_denied_error": True}, 1],
+        ["not_giveup", {}, 5],
+    ])
+    @mock.patch("time.sleep")
+    def test_giveup_for_access_denied_error(self, name, test_data, expected_data, mocked_sleep):
+
+        mocked_method = mock.Mock()
+        mocked_method.side_effect = get
+
+        # Create PageIterator object
+        page_iter = PageIterator(
+            method=mocked_method,
+            input_token=None,
+            output_token=None,
+            more_results=None,
+            result_keys=None,
+            non_aggregate_keys=None,
+            limit_key=None,
+            max_items=None,
+            starting_token=None,
+            page_size=None,
+            op_kwargs=None,
+        )
+
+        with self.assertRaises(ClientError) as e:
+            # Function call
+            page_iter._make_request(test_data)
+
+        # Verify the call count
+        self.assertEqual(mocked_method.call_count, expected_data)


### PR DESCRIPTION
# Description of change
- Updated error doc to Python 3.9 for regex error
- Removed backoff for Access Denied for ClientError

# Manual QA steps
 - Tested locally with cloned connection
 
# Risks
 - Fails faster on access denied errors
 
# Rollback steps
 - revert this branch
