### PR TITLE
Tdl 25859/handle s3 files race condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ jobs:
       - run:
           name: 'Integration Tests'
           command: |
-            aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-            aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-s3-csv/bin/activate
             pip install .
             pip install pylint
-            pylint tap_s3_csv -d duplicate-code,consider-using-f-string,logging-format-interpolation,missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,broad-except,bare-except,unused-variable,unnecessary-comprehension,no-member,deprecated-method,protected-access,broad-exception-raised
+            pylint tap_s3_csv -d duplicate-code,consider-using-f-string,logging-format-interpolation,missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,broad-except,bare-except,unused-variable,unnecessary-comprehension,no-member,deprecated-method,protected-access,broad-exception-raised,too-many-positional-arguments
       - run:
           name: 'Unit Tests'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.3.9
+  * Handle S3 files race condition
+  * [#67](https://github.com/singer-io/tap-s3-csv/pull/67)
+
 ## 1.3.8
   * Add Missing Type Information in JSON Schema
-  * [#55](https://github.com/singer-io/tap-s3-csv/pull/62)
+  * [#62](https://github.com/singer-io/tap-s3-csv/pull/62)
 
 ## 1.3.7
   * Remove Backoff for Access Denied errors

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.3.8',
+      version='1.3.9',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -75,8 +75,8 @@ def main():
     config = args.config
 
     config['tables'] = validate_table_config(config)
-    now = datetime.now()
-    sync_start_time = singer_utils.strptime_with_tz(now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    now_str = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    sync_start_time = singer_utils.strptime_with_tz(now_str)
 
     try:
         for page in s3.list_files_in_bucket(config):

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 import json
 import sys
 import singer
 
 from singer import metadata
+from singer import utils as singer_utils
 from tap_s3_csv.discover import discover_streams
 from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
@@ -27,7 +29,7 @@ def stream_is_selected(mdata):
     return mdata.get((), {}).get('selected', False)
 
 
-def do_sync(config, catalog, state):
+def do_sync(config, catalog, state, sync_start_time):
     LOGGER.info('Starting sync.')
 
     for stream in catalog['streams']:
@@ -43,7 +45,7 @@ def do_sync(config, catalog, state):
         singer.write_schema(stream_name, stream['schema'], key_properties)
 
         LOGGER.info("%s: Starting sync", stream_name)
-        counter_value = sync_stream(config, state, table_spec, stream)
+        counter_value = sync_stream(config, state, table_spec, stream, sync_start_time)
         LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter_value)
 
     LOGGER.info('Done syncing.')
@@ -73,7 +75,7 @@ def main():
     config = args.config
 
     config['tables'] = validate_table_config(config)
-
+    sync_start_time = singer_utils.strptime_with_tz(datetime.now())
     try:
         for page in s3.list_files_in_bucket(config):
             break
@@ -84,7 +86,7 @@ def main():
     if args.discover:
         do_discover(args.config)
     elif args.properties:
-        do_sync(config, args.properties, args.state)
+        do_sync(config, args.properties, args.state, sync_start_time)
 
 
 if __name__ == '__main__':

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -75,7 +75,9 @@ def main():
     config = args.config
 
     config['tables'] = validate_table_config(config)
-    sync_start_time = singer_utils.strptime_with_tz(datetime.now())
+    now = datetime.now()
+    sync_start_time = singer_utils.strptime_with_tz(now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
     try:
         for page in s3.list_files_in_bucket(config):
             break

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -452,9 +452,9 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
         if matcher.search(key):
             matched_files_count += 1
             if modified_since is None or modified_since < last_modified:
-                # LOGGER.info('Will download key "%s" as it was last modified %s',
-                #             key,
-                #             last_modified)
+                LOGGER.info('Will download key "%s" as it was last modified %s',
+                            key,
+                            last_modified)
                 yield {'key': key, 'last_modified': last_modified}
         else:
             unmatched_files_count += 1

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -452,9 +452,9 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
         if matcher.search(key):
             matched_files_count += 1
             if modified_since is None or modified_since < last_modified:
-                LOGGER.info('Will download key "%s" as it was last modified %s',
-                            key,
-                            last_modified)
+                # LOGGER.info('Will download key "%s" as it was last modified %s',
+                #             key,
+                #             last_modified)
                 yield {'key': key, 'last_modified': last_modified}
         else:
             unmatched_files_count += 1

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -30,7 +30,7 @@ def sync_stream(config, state, table_spec, stream, sync_start_time):
 
     s3_files = s3.get_input_files_for_table(
         config, table_spec, modified_since)
-
+    LOGGER.info("****-- s3_files--:%s", s3_files)
     records_streamed = 0
 
     # We sort here so that tracking the modified_since bookmark makes

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -30,7 +30,7 @@ def sync_stream(config, state, table_spec, stream, sync_start_time):
 
     s3_files = s3.get_input_files_for_table(
         config, table_spec, modified_since)
-    LOGGER.info("****-- s3_files--:%s", len(s3_files))
+    LOGGER.info("****-- s3_files--:%s", s3_files)
     records_streamed = 0
 
     # We sort here so that tracking the modified_since bookmark makes
@@ -39,7 +39,7 @@ def sync_stream(config, state, table_spec, stream, sync_start_time):
     # based on anything else then we could just sync files as we see them.
     # Sort using a generator expression
     sorted_files = sorted(s3_files, key=lambda item: item['last_modified'])
-    LOGGER.info("**** sorted_files--:%s", sorted_files)
+    LOGGER.info("**** sorted_files--:%s", len(sorted_files))
     for s3_file in sorted_files:
         records_streamed += sync_table_file(
             config, s3_file['key'], table_spec, stream)

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -30,14 +30,17 @@ def sync_stream(config, state, table_spec, stream, sync_start_time):
 
     s3_files = s3.get_input_files_for_table(
         config, table_spec, modified_since)
-    LOGGER.info("****-- s3_files--:%s", s3_files)
+    LOGGER.info("****-- s3_files--:%s", len(s3_files))
     records_streamed = 0
 
     # We sort here so that tracking the modified_since bookmark makes
     # sense. This means that we can't sync s3 buckets that are larger than
     # we can sort in memory which is suboptimal. If we could bookmark
     # based on anything else then we could just sync files as we see them.
-    for s3_file in sorted(s3_files, key=lambda item: item['last_modified']):
+    # Sort using a generator expression
+    sorted_files = sorted(s3_files, key=lambda item: item['last_modified'])
+    LOGGER.info("**** sorted_files--:%s", sorted_files)
+    for s3_file in sorted_files:
         records_streamed += sync_table_file(
             config, s3_file['key'], table_spec, stream)
 

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -21,7 +21,7 @@ from tap_s3_csv import (
 
 LOGGER = singer.get_logger()
 
-def external_sort_large_dataset(s3_files, chunk_size=2000):
+def external_sort_large_dataset(s3_files, chunk_size=1000):
     chunks = []
     chunk = []
 

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -41,7 +41,7 @@ def sync_stream(config, state, table_spec, stream, sync_start_time):
         records_streamed += sync_table_file(
             config, s3_file['key'], table_spec, stream)
 
-    state = singer.write_bookmark(state, table_name, 'modified_since', sync_start_time)
+    state = singer.write_bookmark(state, table_name, 'modified_since', sync_start_time.isoformat())
     singer.write_state(state)
 
     if s3.skipped_files_count:

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -20,7 +20,7 @@ from tap_s3_csv import (
 
 LOGGER = singer.get_logger()
 
-def sync_stream(config, state, table_spec, stream):
+def sync_stream(config, state, table_spec, stream, sync_start_time):
     table_name = table_spec['table_name']
     modified_since = singer_utils.strptime_with_tz(singer.get_bookmark(state, table_name, 'modified_since') or
                                             config['start_date'])
@@ -41,8 +41,8 @@ def sync_stream(config, state, table_spec, stream):
         records_streamed += sync_table_file(
             config, s3_file['key'], table_spec, stream)
 
-        state = singer.write_bookmark(state, table_name, 'modified_since', s3_file['last_modified'].isoformat())
-        singer.write_state(state)
+    state = singer.write_bookmark(state, table_name, 'modified_since', sync_start_time)
+    singer.write_state(state)
 
     if s3.skipped_files_count:
         LOGGER.warn("%s files got skipped during the last sync.",s3.skipped_files_count)

--- a/tests/unittests/test_sync_stream.py
+++ b/tests/unittests/test_sync_stream.py
@@ -11,58 +11,55 @@ class TestSyncStream(unittest.TestCase):
     @patch('tap_s3_csv.singer.write_bookmark')
     @patch('tap_s3_csv.singer.write_state')
     @patch('tap_s3_csv.LOGGER')
-    def test_sync_stream_with_files_older_than_sync_start_time(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
+    def test_sync_stream_with_files(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
         """
-        Tests the sync_stream function when the last_modified date of files is earlier than sync_start_time.
-        In this case, the bookmark is updated to the last_modified date of the file.
+        Tests the sync_stream function with various file modification times.
+        Depending on whether the last_modified date is earlier or later than sync_start_time,
+        the bookmark will either be updated to the file's last_modified or the sync_start_time.
         """
-        mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
-        mock_get_input_files_for_table.return_value = [
-            {'key': 'file1.csv', 'last_modified': datetime(2024, 8, 13, 12, 0, 0)}
+        test_cases = [
+            # Case when file is older than sync_start_time
+            {
+                "file_last_modified": datetime(2024, 8, 13, 12, 0, 0),
+                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
+                "expected_bookmark": '2024-08-13T12:00:00',
+                "expected_records_streamed": 1
+            },
+            # Case when file is newer than sync_start_time
+            {
+                "file_last_modified": datetime(2024, 8, 15, 12, 0, 0),
+                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
+                "expected_bookmark": '2024-08-14T12:00:00',
+                "expected_records_streamed": 1
+            },
+                        # Case when file is newer than sync_start_time
+            {
+                "file_last_modified": datetime(2024, 8, 14, 12, 0, 0),
+                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
+                "expected_bookmark": '2024-08-14T12:00:00',
+                "expected_records_streamed": 1
+            }
         ]
+
+        mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
         mock_sync_table_file.return_value = 1
-        mock_write_bookmark.return_value = '2024-08-13T12:00:00Z'
+        mock_write_state.return_value = None
 
         config = {'start_date': '2024-01-01T00:00:00Z'}
         state = {}
         table_spec = {'table_name': 'test_table'}
         stream = None
-        sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
 
-        records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
+        for case in test_cases:
+            with self.subTest(case=case):
+                mock_get_input_files_for_table.return_value = [{'key': 'file1.csv', 'last_modified': case["file_last_modified"]}]
+                mock_write_bookmark.return_value = case["expected_bookmark"]
 
-        self.assertEqual(records_streamed, 1)
-        # Verify that the bookmark was updated to the last_modified date of the file
-        mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', '2024-08-13T12:00:00')
-        mock_write_state.assert_called_once()
+                records_streamed = sync_stream(config, state, table_spec, stream, case["sync_start_time"])
 
-    @patch('tap_s3_csv.s3.get_input_files_for_table')
-    @patch('tap_s3_csv.sync.sync_table_file')
-    @patch('tap_s3_csv.singer.get_bookmark')
-    @patch('tap_s3_csv.singer.write_bookmark')
-    @patch('tap_s3_csv.singer.write_state')
-    @patch('tap_s3_csv.LOGGER')
-    def test_sync_stream_with_files_newer_than_sync_start_time(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
-        """
-        Tests the sync_stream function when the last_modified date of files is later than sync_start_time.
-        In this case, the bookmark is updated to sync_start_time.
-        """
-        mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
-        mock_get_input_files_for_table.return_value = [
-            {'key': 'file1.csv', 'last_modified': datetime(2024, 8, 15, 12, 0, 0)}
-        ]
-        mock_sync_table_file.return_value = 1
-        mock_write_bookmark.return_value = '2024-08-15T12:00:00Z'
+                self.assertEqual(records_streamed, case["expected_records_streamed"])
+                mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', case["expected_bookmark"])
 
-        config = {'start_date': '2024-01-01T00:00:00Z'}
-        state = {}
-        table_spec = {'table_name': 'test_table'}
-        stream = None
-        sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
-
-        records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
-
-        self.assertEqual(records_streamed, 1)
-        # Verify that the bookmark was updated to the sync_start_time
-        mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', sync_start_time.isoformat())
-        mock_write_state.assert_called_once()
+                # Ensure `write_state` is called exactly once for each test case
+                mock_write_state.assert_called_once()
+                mock_write_state.reset_mock()  # Reset the mock call count for the next subtest

--- a/tests/unittests/test_sync_stream.py
+++ b/tests/unittests/test_sync_stream.py
@@ -25,10 +25,8 @@ class TestSyncStream(unittest.TestCase):
         stream = None
         sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
 
-        # Act
         records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
 
-        # Assert
         self.assertEqual(records_streamed, 1)
         # Check that the bookmark was set to the last_modified date of the file
         mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', '2024-08-13T12:00:00')
@@ -54,10 +52,8 @@ class TestSyncStream(unittest.TestCase):
         stream = None
         sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
 
-        # Act
         records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
 
-        # Assert
         self.assertEqual(records_streamed, 1)
         mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', sync_start_time.isoformat())
         mock_write_state.assert_called_once()

--- a/tests/unittests/test_sync_stream.py
+++ b/tests/unittests/test_sync_stream.py
@@ -2,45 +2,28 @@ import unittest
 from unittest.mock import patch, MagicMock
 from datetime import datetime
 from tap_s3_csv import sync_stream
+from parameterized import parameterized
 
 class TestSyncStream(unittest.TestCase):
 
+    @parameterized.expand([
+        # Case when file is older than sync_start_time
+        ("file_older_than_sync_start_time", datetime(2024, 8, 13, 12, 0, 0), datetime(2024, 8, 14, 12, 0, 0), '2024-08-13T12:00:00', 1),
+        # Case when file is newer than sync_start_time
+        ("file_newer_than_sync_start_time", datetime(2024, 8, 15, 12, 0, 0), datetime(2024, 8, 14, 12, 0, 0), '2024-08-14T12:00:00', 1),
+        # Case when file is the same as sync_start_time
+        ("file_same_as_sync_start_time", datetime(2024, 8, 14, 12, 0, 0), datetime(2024, 8, 14, 12, 0, 0), '2024-08-14T12:00:00', 1)
+    ])
     @patch('tap_s3_csv.s3.get_input_files_for_table')
     @patch('tap_s3_csv.sync.sync_table_file')
     @patch('tap_s3_csv.singer.get_bookmark')
     @patch('tap_s3_csv.singer.write_bookmark')
     @patch('tap_s3_csv.singer.write_state')
     @patch('tap_s3_csv.LOGGER')
-    def test_sync_stream_with_files(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
+    def test_sync_stream(self, name, file_last_modified, sync_start_time, expected_bookmark, expected_records_streamed, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
         """
-        Tests the sync_stream function with various file modification times.
-        Depending on whether the last_modified date is earlier or later than sync_start_time,
-        the bookmark will either be updated to the file's last_modified or the sync_start_time.
+        Parameterized test for the sync_stream function with various file modification times.
         """
-        test_cases = [
-            # Case when file is older than sync_start_time
-            {
-                "file_last_modified": datetime(2024, 8, 13, 12, 0, 0),
-                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
-                "expected_bookmark": '2024-08-13T12:00:00',
-                "expected_records_streamed": 1
-            },
-            # Case when file is newer than sync_start_time
-            {
-                "file_last_modified": datetime(2024, 8, 15, 12, 0, 0),
-                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
-                "expected_bookmark": '2024-08-14T12:00:00',
-                "expected_records_streamed": 1
-            },
-                        # Case when file is newer than sync_start_time
-            {
-                "file_last_modified": datetime(2024, 8, 14, 12, 0, 0),
-                "sync_start_time": datetime(2024, 8, 14, 12, 0, 0),
-                "expected_bookmark": '2024-08-14T12:00:00',
-                "expected_records_streamed": 1
-            }
-        ]
-
         mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
         mock_sync_table_file.return_value = 1
         mock_write_state.return_value = None
@@ -50,16 +33,12 @@ class TestSyncStream(unittest.TestCase):
         table_spec = {'table_name': 'test_table'}
         stream = None
 
-        for case in test_cases:
-            with self.subTest(case=case):
-                mock_get_input_files_for_table.return_value = [{'key': 'file1.csv', 'last_modified': case["file_last_modified"]}]
-                mock_write_bookmark.return_value = case["expected_bookmark"]
+        mock_get_input_files_for_table.return_value = [{'key': 'file1.csv', 'last_modified': file_last_modified}]
+        mock_write_bookmark.return_value = expected_bookmark
 
-                records_streamed = sync_stream(config, state, table_spec, stream, case["sync_start_time"])
+        records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
 
-                self.assertEqual(records_streamed, case["expected_records_streamed"])
-                mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', case["expected_bookmark"])
-
-                # Ensure `write_state` is called exactly once for each test case
-                mock_write_state.assert_called_once()
-                mock_write_state.reset_mock()  # Reset the mock call count for the next subtest
+        self.assertEqual(records_streamed, expected_records_streamed)
+        mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', expected_bookmark)
+        mock_write_state.assert_called_once()
+        mock_write_state.reset_mock()

--- a/tests/unittests/test_sync_stream.py
+++ b/tests/unittests/test_sync_stream.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+from tap_s3_csv import sync_stream
+
+class TestSyncStream(unittest.TestCase):
+
+    @patch('tap_s3_csv.s3.get_input_files_for_table')
+    @patch('tap_s3_csv.sync.sync_table_file')
+    @patch('tap_s3_csv.singer.get_bookmark')
+    @patch('tap_s3_csv.singer.write_bookmark')
+    @patch('tap_s3_csv.singer.write_state')
+    @patch('tap_s3_csv.LOGGER')
+    def test_sync_stream_if_block(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
+        mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
+        mock_get_input_files_for_table.return_value = [
+            {'key': 'file1.csv', 'last_modified': datetime(2024, 8, 13, 12, 0, 0)}
+        ]
+        mock_sync_table_file.return_value = 1
+        mock_write_bookmark.return_value = '2024-08-13T12:00:00Z'
+
+        config = {'start_date': '2024-01-01T00:00:00Z'}
+        state = {}
+        table_spec = {'table_name': 'test_table'}
+        stream = None
+        sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
+
+        # Act
+        records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
+
+        # Assert
+        self.assertEqual(records_streamed, 1)
+        # Check that the bookmark was set to the last_modified date of the file
+        mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', '2024-08-13T12:00:00')
+        mock_write_state.assert_called_once()
+
+    @patch('tap_s3_csv.s3.get_input_files_for_table')
+    @patch('tap_s3_csv.sync.sync_table_file')
+    @patch('tap_s3_csv.singer.get_bookmark')
+    @patch('tap_s3_csv.singer.write_bookmark')
+    @patch('tap_s3_csv.singer.write_state')
+    @patch('tap_s3_csv.LOGGER')
+    def test_sync_stream_else_block(self, mock_logger, mock_write_state, mock_write_bookmark, mock_get_bookmark, mock_sync_table_file, mock_get_input_files_for_table):
+        mock_get_bookmark.return_value = '2024-01-01T00:00:00Z'
+        mock_get_input_files_for_table.return_value = [
+            {'key': 'file1.csv', 'last_modified': datetime(2024, 8, 15, 12, 0, 0)}
+        ]
+        mock_sync_table_file.return_value = 1
+        mock_write_bookmark.return_value = '2024-08-15T12:00:00Z'
+
+        config = {'start_date': '2024-01-01T00:00:00Z'}
+        state = {}
+        table_spec = {'table_name': 'test_table'}
+        stream = None
+        sync_start_time = datetime(2024, 8, 14, 12, 0, 0)
+
+        # Act
+        records_streamed = sync_stream(config, state, table_spec, stream, sync_start_time)
+
+        # Assert
+        self.assertEqual(records_streamed, 1)
+        mock_write_bookmark.assert_called_with(state, 'test_table', 'modified_since', sync_start_time.isoformat())
+        mock_write_state.assert_called_once()


### PR DESCRIPTION
# Description of change
This PR addresses the issue of S3 file race conditions where the last_modified timestamps of S3 files are being updated while extractions are in progress, causing the bookmark time to advance beyond the current execution time.

**Resolution:**
- Record the `sync_start_time` at the beginning of the extraction.
- Check if the file's `last_modified` is greater than the `sync_start_time`.
  - If so, store the `sync_start_time` as the bookmark in the state.
  - Otherwise, store the file's `last_modified` timestamp in the state file.

# Manual QA steps
 - tested on the client connection
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
