### PR TITLE
Tdl-27000 add credentials_cache_path property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.1
+## 1.5.0
   * Changes JSONFileCache location [#70](https://github.com/singer-io/tap-s3-csv/pull/70)
 
 ## 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.1
+  * Changes JSONFileCache location [#70](https://github.com/singer-io/tap-s3-csv/pull/70)
+
 ## 1.4.0
   * Adds proxy AWS Account support
   * [#69](https://github.com/singer-io/tap-s3-csv/pull/69)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.4.0',
+      version='1.4.1',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='1.4.1',
+      version='1.5.0',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -121,6 +121,7 @@ def setup_aws_client_with_proxy(config):
     proxy_role_arn = "arn:aws:iam::{}:role/{}".format(config['proxy_account_id'].replace('-', ''),
                                                           config['proxy_role_name'])
     cust_role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''), config['role_name'])
+    credentials_cache_path = config.get("credentials_cache_path", JSONFileCache.CACHE_DIR)
 
     # Step 1: Assume Role in Account Proxy and set up refreshable session
     session_proxy = Session()
@@ -132,7 +133,7 @@ def setup_aws_client_with_proxy(config):
             'DurationSeconds': 3600,
             'RoleSessionName': 'ProxySession'
         },
-        cache=JSONFileCache("/tmp")
+        cache=JSONFileCache(credentials_cache_path)
     )
 
     # Refreshable credentials for Account Proxy
@@ -153,7 +154,7 @@ def setup_aws_client_with_proxy(config):
             'RoleSessionName': 'TapS3CSVCustSession',
             'ExternalId': config['external_id']
         },
-        cache=JSONFileCache("/tmp")
+        cache=JSONFileCache(credentials_cache_path)
     )
 
     # Set up refreshable session for Customer Account

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -132,7 +132,7 @@ def setup_aws_client_with_proxy(config):
             'DurationSeconds': 3600,
             'RoleSessionName': 'ProxySession'
         },
-        cache=JSONFileCache()
+        cache=JSONFileCache("/tmp")
     )
 
     # Refreshable credentials for Account Proxy
@@ -153,7 +153,7 @@ def setup_aws_client_with_proxy(config):
             'RoleSessionName': 'TapS3CSVCustSession',
             'ExternalId': config['external_id']
         },
-        cache=JSONFileCache()
+        cache=JSONFileCache("/tmp")
     )
 
     # Set up refreshable session for Customer Account


### PR DESCRIPTION
# Description of change
Adds `credentials_cache_path` property to customize where the JSONFileCache is stored.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
