### PR TITLE
bump singer-encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.5
+  * Bumps singer-econdings to remove pyarrow vulnerability
+
 ## 2.2.4
   * Write bookmarks for streams that sync no records [#87](https://github.com/singer-io/tap-s3-csv/pull/87)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='tap-s3-csv',
           'backoff==1.10.0',
           'boto3==1.39.8',
           'urllib3==2.6.3',
-          'singer-encodings==0.3.0',
+          'singer-encodings==0.5.0',
           'singer-python==5.19.0',
           'voluptuous==0.15.2',
           's3fs==2025.9.0'


### PR DESCRIPTION
# Description of change
Vulnerability CVE-2026-25087 is covered by bumping singer-encodings which includes a newer version of pyarrow

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
