### PR TITLE
Exclude unauthorized streams during discovery (403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.3.0
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error for the entire run.
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error for the entire run. [#90](https://github.com/singer-io/tap-s3-csv/pull/90)
 
 ## 2.2.5
   * Bump urllib3 to 2.7.0 for security updates [#89](https://github.com/singer-io/tap-s3-csv/pull/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error for the entire run.
+
 ## 2.2.5
   * Bump urllib3 to 2.7.0 for security updates [#89](https://github.com/singer-io/tap-s3-csv/pull/89)
   * Bumps singer-econdings to remove pyarrow vulnerability [#88](https://github.com/singer-io/tap-s3-csv/pull/88)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='2.2.5',
+    version='2.3.0',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -9,15 +9,16 @@ from tap_s3_csv.discover import discover_streams
 from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
 from tap_s3_csv.config import CONFIG_CONTRACT
+from tap_s3_csv.client import S3CsvClient
 
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ["start_date", "bucket", "account_id", "external_id", "role_name"]
 
 
-def do_discover(config):
+def do_discover(config, client):
     LOGGER.info("Starting discover")
-    streams = discover_streams(config)
+    streams = discover_streams(config, client)
     if not streams:
         raise Exception("No streams found")
     catalog = {"streams": streams}
@@ -98,12 +99,13 @@ def main():
             s3.setup_aws_client(config)
             s3.setup_s3fs_client(config)
 
-    if args.discover:
-        do_discover(args.config)
-    elif args.catalog:
-        do_sync(config, args.catalog.to_dict(), args.state, sync_start_time)
-    elif args.properties:
-        do_sync(config, args.properties, args.state, sync_start_time)
+    with S3CsvClient(config) as client:
+        if args.discover:
+            do_discover(config, client)
+        elif args.catalog:
+            do_sync(config, args.catalog.to_dict(), args.state, sync_start_time)
+        elif args.properties:
+            do_sync(config, args.properties, args.state, sync_start_time)
 
 
 if __name__ == '__main__':

--- a/tap_s3_csv/client.py
+++ b/tap_s3_csv/client.py
@@ -1,0 +1,40 @@
+from botocore.exceptions import ClientError
+
+from tap_s3_csv import s3
+from tap_s3_csv.exceptions import S3CsvForbiddenError
+
+
+def _is_forbidden_client_error(error):
+    if not isinstance(error, ClientError):
+        return False
+    code = error.response.get("Error", {}).get("Code")
+    status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    return code in ("AccessDenied", "UnauthorizedOperation") or status_code == 403
+
+
+class S3CsvClient:
+    def __init__(self, config):
+        self.config = config
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def make_request(self, method, _url=None, params=None, _headers=None, body=None):
+        if method != "LIST":
+            raise NotImplementedError("S3CsvClient supports only LIST method for access checks")
+
+        search_prefix = (params or {}).get("search_prefix")
+        try:
+            next(s3.list_files_in_bucket(self.config, search_prefix), None)
+        except ClientError as error:
+            if _is_forbidden_client_error(error):
+                raise S3CsvForbiddenError(
+                    "HTTP-error-code: 403, Error: The credentials do not have read access to this S3 resource.",
+                    error.response,
+                ) from error
+            raise
+
+        return None

--- a/tap_s3_csv/client.py
+++ b/tap_s3_csv/client.py
@@ -22,7 +22,7 @@ class S3CsvClient:
     def __exit__(self, exc_type, exc_value, traceback):
         pass
 
-    def make_request(self, method, _url=None, params=None, _headers=None, body=None):
+    def make_request(self, method, params=None):
         if method != "LIST":
             raise NotImplementedError("S3CsvClient supports only LIST method for access checks")
 

--- a/tap_s3_csv/client.py
+++ b/tap_s3_csv/client.py
@@ -22,7 +22,7 @@ class S3CsvClient:
     def __exit__(self, exc_type, exc_value, traceback):
         pass
 
-    def make_request(self, method, _url=None, params=None, _headers=None, _body=None):
+    def make_request(self, method, _url=None, params=None, _headers=None, body=None):
         if method != "LIST":
             raise NotImplementedError("S3CsvClient supports only LIST method for access checks")
 

--- a/tap_s3_csv/client.py
+++ b/tap_s3_csv/client.py
@@ -36,5 +36,3 @@ class S3CsvClient:
                     error.response,
                 ) from error
             raise
-
-        return None

--- a/tap_s3_csv/client.py
+++ b/tap_s3_csv/client.py
@@ -20,9 +20,9 @@ class S3CsvClient:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        return False
+        pass
 
-    def make_request(self, method, _url=None, params=None, _headers=None, body=None):
+    def make_request(self, method, _url=None, params=None, _headers=None, _body=None):
         if method != "LIST":
             raise NotImplementedError("S3CsvClient supports only LIST method for access checks")
 

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -1,14 +1,112 @@
 from singer import metadata
 from tap_s3_csv import s3
+import singer
+
+from tap_s3_csv.exceptions import S3CsvForbiddenError
+
+LOGGER = singer.get_logger()
 
 
-def discover_streams(config):
+class TableStream:
+    parent = None
+
+    def __init__(self, table_spec, client=None):
+        self.table_spec = table_spec
+        self.client = client
+
+    def get_url_endpoint(self):
+        prefix = self.table_spec.get('search_prefix')
+        if prefix:
+            return "s3://{}/{}".format(self.client.config['bucket'], prefix)
+        return "s3://{}".format(self.client.config['bucket'])
+
+    def update_params(self):
+        return {'search_prefix': self.table_spec.get('search_prefix')}
+
+    def check_access(self):
+        if self.parent:
+            return True
+
+        if self.client is None:
+            return True
+
+        try:
+            self.client.make_request(
+                "LIST",
+                self.get_url_endpoint(),
+                self.update_params(),
+                None,
+                body=None,
+            )
+            return True
+        except S3CsvForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.table_spec.get('table_name'),
+                exc,
+            )
+            return False
+
+
+def _prune_inaccessible_children(table_specs, schemas: dict, field_metadata: dict) -> None:
+    table_map = {table_spec['table_name']: table_spec for table_spec in table_specs}
+    for name, table_spec in list(table_map.items()):
+        parent_name = table_spec.get('parent')
+        if name in schemas and parent_name and parent_name not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name,
+                parent_name,
+            )
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
+
+
+def _apply_access_checks(client, table_specs, schemas: dict, field_metadata: dict) -> None:
+    inaccessible_streams = [
+        table_spec['table_name']
+        for table_spec in table_specs
+        if table_spec['table_name'] in schemas
+        and not TableStream(table_spec=table_spec, client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(table_specs, schemas, field_metadata)
+
+    if not schemas:
+        raise S3CsvForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
+        )
+    if inaccessible_streams:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover_streams(config, client=None):
     streams = []
+    schemas = {}
+    field_metadata = {}
 
     for table_spec in config['tables']:
+        stream_name = table_spec['table_name']
         schema = discover_schema(config, table_spec)
-        streams.append({'stream': table_spec['table_name'], 'tap_stream_id': table_spec['table_name'],
-                       'schema': schema, 'metadata': load_metadata(table_spec, schema)})
+        schemas[stream_name] = schema
+        field_metadata[stream_name] = load_metadata(table_spec, schema)
+
+    if client is not None:
+        _apply_access_checks(client, config['tables'], schemas, field_metadata)
+
+    for table_spec in config['tables']:
+        stream_name = table_spec['table_name']
+        if stream_name not in schemas:
+            continue
+        streams.append({'stream': stream_name, 'tap_stream_id': stream_name,
+                       'schema': schemas[stream_name], 'metadata': field_metadata[stream_name]})
     return streams
 
 

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -24,12 +24,6 @@ class TableStream:
         return {'search_prefix': self.table_spec.get('search_prefix')}
 
     def check_access(self):
-        if self.parent:
-            return True
-
-        if self.client is None:
-            return True
-
         try:
             self.client.make_request("LIST", self.update_params())
             return True

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -1,7 +1,7 @@
-from singer import metadata
-from tap_s3_csv import s3
 import singer
+from singer import metadata
 
+from tap_s3_csv import s3
 from tap_s3_csv.exceptions import S3CsvForbiddenError
 
 LOGGER = singer.get_logger()

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -31,13 +31,7 @@ class TableStream:
             return True
 
         try:
-            self.client.make_request(
-                "LIST",
-                self.get_url_endpoint(),
-                self.update_params(),
-                None,
-                body=None,
-            )
+            self.client.make_request("LIST", self.update_params())
             return True
         except S3CsvForbiddenError as exc:
             LOGGER.warning(

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -42,43 +42,54 @@ class TableStream:
             return False
 
 
-def _prune_inaccessible_children(table_specs, schemas: dict, field_metadata: dict) -> None:
-    table_map = {table_spec['table_name']: table_spec for table_spec in table_specs}
-    for name, table_spec in list(table_map.items()):
+def _prune_inaccessible_children(table_specs, accessible_stream_names):
+    filtered_table_specs = []
+
+    for table_spec in table_specs:
+        stream_name = table_spec['table_name']
         parent_name = table_spec.get('parent')
-        if name in schemas and parent_name and parent_name not in schemas:
+
+        if stream_name not in accessible_stream_names:
+            continue
+
+        if parent_name and parent_name not in accessible_stream_names:
             LOGGER.warning(
                 "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                name,
+                stream_name,
                 parent_name,
             )
-            schemas.pop(name, None)
-            field_metadata.pop(name, None)
+            continue
+
+        filtered_table_specs.append(table_spec)
+
+    return filtered_table_specs
 
 
-def _apply_access_checks(client, table_specs, schemas: dict, field_metadata: dict) -> None:
-    inaccessible_streams = [
-        table_spec['table_name']
-        for table_spec in table_specs
-        if table_spec['table_name'] in schemas
-        and not TableStream(table_spec=table_spec, client=client).check_access()
-    ]
+def _apply_access_checks(client, table_specs):
+    accessible_stream_names = []
+    inaccessible_stream_names = []
 
-    for stream_name in inaccessible_streams:
-        schemas.pop(stream_name, None)
-        field_metadata.pop(stream_name, None)
+    for table_spec in table_specs:
+        stream_name = table_spec['table_name']
+        if TableStream(table_spec=table_spec, client=client).check_access():
+            accessible_stream_names.append(stream_name)
+        else:
+            inaccessible_stream_names.append(stream_name)
 
-    _prune_inaccessible_children(table_specs, schemas, field_metadata)
+    accessible_table_specs = _prune_inaccessible_children(table_specs, accessible_stream_names)
 
-    if not schemas:
+    if not accessible_table_specs:
         raise S3CsvForbiddenError(
             "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
         )
-    if inaccessible_streams:
+
+    if inaccessible_stream_names:
         LOGGER.warning(
             "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(inaccessible_streams),
+            ", ".join(inaccessible_stream_names),
         )
+
+    return accessible_table_specs
 
 
 def discover_streams(config, client=None):
@@ -86,16 +97,17 @@ def discover_streams(config, client=None):
     schemas = {}
     field_metadata = {}
 
-    for table_spec in config['tables']:
+    table_specs = config['tables']
+    if client is not None:
+        table_specs = _apply_access_checks(client, table_specs)
+
+    for table_spec in table_specs:
         stream_name = table_spec['table_name']
         schema = discover_schema(config, table_spec)
         schemas[stream_name] = schema
         field_metadata[stream_name] = load_metadata(table_spec, schema)
 
-    if client is not None:
-        _apply_access_checks(client, config['tables'], schemas, field_metadata)
-
-    for table_spec in config['tables']:
+    for table_spec in table_specs:
         stream_name = table_spec['table_name']
         if stream_name not in schemas:
             continue

--- a/tap_s3_csv/exceptions.py
+++ b/tap_s3_csv/exceptions.py
@@ -1,0 +1,4 @@
+class S3CsvForbiddenError(Exception):
+    def __init__(self, message, response=None):
+        super().__init__(message)
+        self.response = response

--- a/tests/unittests/test_discovery_access.py
+++ b/tests/unittests/test_discovery_access.py
@@ -1,9 +1,10 @@
 import unittest
 import sys
-from unittest.mock import patch
+from importlib import import_module
+from unittest.mock import MagicMock, patch
 
 
-for module_name in [
+MODULE_NAMES = [
     "boto3",
     "s3fs",
     "botocore",
@@ -23,16 +24,27 @@ for module_name in [
     "singer_encodings.jsonl",
     "singer_encodings.parquet",
     "voluptuous",
-]:
-    if module_name not in sys.modules:
-        from unittest.mock import MagicMock
-        sys.modules[module_name] = MagicMock()
-
-from tap_s3_csv.discover import discover_streams
-from tap_s3_csv.exceptions import S3CsvForbiddenError
-
+]
 
 class DiscoveryAccessTests(unittest.TestCase):
+    def setUp(self):
+        self._module_patch = patch.dict(
+            sys.modules,
+            {module_name: MagicMock() for module_name in MODULE_NAMES},
+        )
+        self._module_patch.start()
+
+    def tearDown(self):
+        self._module_patch.stop()
+
+    def _discover_streams(self):
+        discover_module = import_module("tap_s3_csv.discover")
+        return discover_module.discover_streams
+
+    def _forbidden_error(self):
+        exceptions_module = import_module("tap_s3_csv.exceptions")
+        return exceptions_module.S3CsvForbiddenError
+
     def _config(self):
         return {
             "bucket": "bucket",
@@ -57,6 +69,7 @@ class DiscoveryAccessTests(unittest.TestCase):
     @patch("tap_s3_csv.discover.discover_schema")
     @patch("tap_s3_csv.discover.TableStream.check_access")
     def test_discovery_all_accessible(self, mock_check_access, mock_discover_schema):
+        discover_streams = self._discover_streams()
         mock_check_access.return_value = True
         mock_discover_schema.return_value = {
             "type": "object",
@@ -71,6 +84,7 @@ class DiscoveryAccessTests(unittest.TestCase):
     @patch("tap_s3_csv.discover.discover_schema")
     @patch("tap_s3_csv.discover.TableStream.check_access")
     def test_discovery_excludes_inaccessible_streams(self, mock_check_access, mock_discover_schema):
+        discover_streams = self._discover_streams()
         mock_check_access.side_effect = [True, False]
         mock_discover_schema.return_value = {
             "type": "object",
@@ -81,10 +95,14 @@ class DiscoveryAccessTests(unittest.TestCase):
         streams = discover_streams(self._config(), client=client)
 
         self.assertEqual({stream["tap_stream_id"] for stream in streams}, {"accounts"})
+        self.assertEqual(mock_discover_schema.call_count, 1)
+        called_table_spec = mock_discover_schema.call_args[0][1]
+        self.assertEqual(called_table_spec["table_name"], "accounts")
 
     @patch("tap_s3_csv.discover.discover_schema")
     @patch("tap_s3_csv.discover.TableStream.check_access")
     def test_discovery_raises_if_no_stream_accessible(self, mock_check_access, mock_discover_schema):
+        discover_streams = self._discover_streams()
         mock_check_access.return_value = False
         mock_discover_schema.return_value = {
             "type": "object",
@@ -92,12 +110,13 @@ class DiscoveryAccessTests(unittest.TestCase):
         }
 
         client = type("Client", (), {"config": self._config()})()
-        with self.assertRaises(S3CsvForbiddenError):
+        with self.assertRaises(self._forbidden_error()):
             discover_streams(self._config(), client=client)
 
     @patch("tap_s3_csv.discover.discover_schema")
     @patch("tap_s3_csv.discover.TableStream.check_access")
     def test_discovery_prunes_child_if_parent_removed(self, mock_check_access, mock_discover_schema):
+        discover_streams = self._discover_streams()
         config = {
             "bucket": "bucket",
             "tables": [
@@ -124,5 +143,5 @@ class DiscoveryAccessTests(unittest.TestCase):
         }
 
         client = type("Client", (), {"config": config})()
-        with self.assertRaises(S3CsvForbiddenError):
+        with self.assertRaises(self._forbidden_error()):
             discover_streams(config, client=client)

--- a/tests/unittests/test_discovery_access.py
+++ b/tests/unittests/test_discovery_access.py
@@ -1,0 +1,128 @@
+import unittest
+import sys
+from unittest.mock import patch
+
+
+for module_name in [
+    "boto3",
+    "s3fs",
+    "botocore",
+    "botocore.credentials",
+    "botocore.exceptions",
+    "botocore.session",
+    "botocore.config",
+    "botocore.paginate",
+    "aiobotocore",
+    "aiobotocore.credentials",
+    "aiobotocore.session",
+    "singer.schema_generation",
+    "singer_encodings",
+    "singer_encodings.avro",
+    "singer_encodings.compression",
+    "singer_encodings.csv",
+    "singer_encodings.jsonl",
+    "singer_encodings.parquet",
+    "voluptuous",
+]:
+    if module_name not in sys.modules:
+        from unittest.mock import MagicMock
+        sys.modules[module_name] = MagicMock()
+
+from tap_s3_csv.discover import discover_streams
+from tap_s3_csv.exceptions import S3CsvForbiddenError
+
+
+class DiscoveryAccessTests(unittest.TestCase):
+    def _config(self):
+        return {
+            "bucket": "bucket",
+            "tables": [
+                {
+                    "table_name": "accounts",
+                    "search_pattern": "accounts.csv",
+                    "search_prefix": "prefix/accounts",
+                    "key_properties": ["id"],
+                    "date_overrides": [],
+                },
+                {
+                    "table_name": "contacts",
+                    "search_pattern": "contacts.csv",
+                    "search_prefix": "prefix/contacts",
+                    "key_properties": ["id"],
+                    "date_overrides": [],
+                },
+            ],
+        }
+
+    @patch("tap_s3_csv.discover.discover_schema")
+    @patch("tap_s3_csv.discover.TableStream.check_access")
+    def test_discovery_all_accessible(self, mock_check_access, mock_discover_schema):
+        mock_check_access.return_value = True
+        mock_discover_schema.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": ["null", "string"]}},
+        }
+
+        client = type("Client", (), {"config": self._config()})()
+        streams = discover_streams(self._config(), client=client)
+
+        self.assertEqual({stream["tap_stream_id"] for stream in streams}, {"accounts", "contacts"})
+
+    @patch("tap_s3_csv.discover.discover_schema")
+    @patch("tap_s3_csv.discover.TableStream.check_access")
+    def test_discovery_excludes_inaccessible_streams(self, mock_check_access, mock_discover_schema):
+        mock_check_access.side_effect = [True, False]
+        mock_discover_schema.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": ["null", "string"]}},
+        }
+
+        client = type("Client", (), {"config": self._config()})()
+        streams = discover_streams(self._config(), client=client)
+
+        self.assertEqual({stream["tap_stream_id"] for stream in streams}, {"accounts"})
+
+    @patch("tap_s3_csv.discover.discover_schema")
+    @patch("tap_s3_csv.discover.TableStream.check_access")
+    def test_discovery_raises_if_no_stream_accessible(self, mock_check_access, mock_discover_schema):
+        mock_check_access.return_value = False
+        mock_discover_schema.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": ["null", "string"]}},
+        }
+
+        client = type("Client", (), {"config": self._config()})()
+        with self.assertRaises(S3CsvForbiddenError):
+            discover_streams(self._config(), client=client)
+
+    @patch("tap_s3_csv.discover.discover_schema")
+    @patch("tap_s3_csv.discover.TableStream.check_access")
+    def test_discovery_prunes_child_if_parent_removed(self, mock_check_access, mock_discover_schema):
+        config = {
+            "bucket": "bucket",
+            "tables": [
+                {
+                    "table_name": "parent",
+                    "search_pattern": "parent.csv",
+                    "key_properties": ["id"],
+                    "date_overrides": [],
+                },
+                {
+                    "table_name": "child",
+                    "search_pattern": "child.csv",
+                    "key_properties": ["id"],
+                    "date_overrides": [],
+                    "parent": "parent",
+                },
+            ],
+        }
+
+        mock_check_access.side_effect = [False, True]
+        mock_discover_schema.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": ["null", "string"]}},
+        }
+
+        client = type("Client", (), {"config": config})()
+        with self.assertRaises(S3CsvForbiddenError):
+            discover_streams(config, client=client)


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31238

## Summary
This PR adds discovery-time access checks so streams that are not readable with the provided credentials are excluded from the emitted catalog instead of failing the entire discovery run.  
If no streams are accessible, discovery raises a provider-specific forbidden error.

## What changed

### Discovery access checks
- Added access-check logic during discovery to:
  - evaluate stream readability
  - remove inaccessible streams from schemas/metadata
  - prune child streams when parent streams are excluded
- Discovery now fails only when zero streams remain after exclusion.

### Provider-specific error handling
- Added a dedicated forbidden exception for this tap.
- Added client-side mapping for access-denied conditions to that forbidden exception.

### Discovery client plumbing
- Updated discovery flow to accept/use a client object.
- Updated entrypoint discover path to construct and pass the client.

### Tests
- Added unit tests for:
  - all streams accessible
  - partial stream access (excluded streams)
  - no stream access (forbidden error)
  - parent-child pruning behavior

### Release metadata
- Updated version in `setup.py`.
- Added changelog entry describing stream exclusion behavior and tests.

## Why this change
Some S3/IAM configurations allow access to only a subset of configured table patterns. Previously this could fail discovery globally. This change enables partial catalog generation and improves connector resilience in restricted-permission environments.

## Validation
- Ran targeted unit tests for the new behavior:
  - `python -m pytest tests/unittests/test_discovery_access.py -q`
- Result: `4 passed`

## Backward compatibility
- No behavior change when credentials can read all configured streams.
- Sync behavior remains unchanged.
- Discovery behavior improves for partial-access credentials.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
