### PR TITLE
SAC-31618: fix Parquet discovery OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+  * Close file handles after sampling, and reduce Parquet discovery memory usage by sampling rows before converting them to Python objects [#92](https://github.com/singer-io/tap-s3-csv/pull/92)
+
 ## 2.2.5
   * Bump urllib3 to 2.7.0 for security updates [#89](https://github.com/singer-io/tap-s3-csv/pull/89)
   * Bumps singer-econdings to remove pyarrow vulnerability [#88](https://github.com/singer-io/tap-s3-csv/pull/88)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='2.2.5',
+      version='2.3.0',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='tap-s3-csv',
           'backoff==1.10.0',
           'boto3==1.39.8',
           'urllib3==2.7.0',
-          'singer-encodings==0.5.0',
+          'singer-encodings==0.6.0',
           'singer-python==5.19.0',
           'voluptuous==0.15.2',
           's3fs==2025.9.0'

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -592,6 +592,18 @@ def sample_files(config, table_spec, s3_files,
             # Handled both error and skipping file with wrong extension.
             LOGGER.warn("Skipping %s file as parsing failed. Verify an extension of the file.",s3_path)
             skipped_files_count = skipped_files_count + 1
+        finally:
+            # Explicitly release the file handle once sampling is done so the
+            # underlying S3/S3FS connection and read buffers aren't held open
+            # for the entire discovery run (get_files_to_sample keeps every
+            # sampled file's handle alive in a list until this generator
+            # finishes, so relying on refcounting alone doesn't free them
+            # incrementally as each file is processed).
+            if hasattr(file_handle, "close"):
+                try:
+                    file_handle.close()
+                except Exception: #pylint:disable=broad-except
+                    LOGGER.debug('Could not close file handle for "%s"', s3_path)
 
 #pylint: disable=global-statement
 def get_input_files_for_table(config, table_spec, modified_since=None):

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -495,6 +495,10 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension, max_re
         return records
 
     if extension == "parquet":
+        if parquet.is_empty(file_handle):
+            LOGGER.warning('Skipping "%s" file as it is empty',s3_path)
+            skipped_files_count = skipped_files_count + 1
+            return []
         return get_records_for_parquet(s3_path, sample_rate, max_records, file_handle)
 
     if extension == "avro":

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -388,6 +388,23 @@ def get_records_for_iterator(s3_path, sample_rate, iterator):
 
     LOGGER.info("Sampled %s rows from %s", sampled_row_count, s3_path)
 
+def get_records_for_parquet(s3_path, sample_rate, max_records, file_handle):
+    # Unlike the other formats, Parquet sampling filters rows at the
+    # Arrow level (before they're converted to Python objects), via
+    # parquet.sample_row_iterator(), instead of sampling a stream that's
+    # already fully materialized row-by-row. See singer-encodings'
+    # sample_row_iterator() docstring for why this matters for memory.
+    sampled_row_count = 0
+
+    for row in parquet.sample_row_iterator(file_handle, sample_rate, max_records):
+        sampled_row_count += 1
+        if (sampled_row_count % 200) == 0:
+            LOGGER.info("Sampled %s rows from %s",
+                        sampled_row_count, s3_path)
+        yield row
+
+    LOGGER.info("Sampled %s rows from %s", sampled_row_count, s3_path)
+
 def check_key_properties_and_date_overrides_for_jsonl_file(table_spec, jsonl_sample_records, s3_path):
 
     all_keys = set()
@@ -408,7 +425,7 @@ def check_key_properties_and_date_overrides_for_jsonl_file(table_spec, jsonl_sam
                             .format(s3_path, date_overrides - all_keys))
 
 #pylint: disable=global-statement
-def sampling_gz_file(table_spec, s3_path, file_handle, sample_rate):
+def sampling_gz_file(table_spec, s3_path, file_handle, sample_rate, max_records=1000):
     global skipped_files_count
     if s3_path.endswith(".tar.gz"):
         LOGGER.warning('Skipping "%s" file as .tar.gz extension is not supported',s3_path)
@@ -435,12 +452,12 @@ def sampling_gz_file(table_spec, s3_path, file_handle, sample_rate):
             return []
 
         gz_file_extension = gz_file_name.split(".")[-1].lower()
-        return sample_file(table_spec, s3_path + "/" + gz_file_name, io.BytesIO(gz_file_obj.read()), sample_rate, gz_file_extension)
+        return sample_file(table_spec, s3_path + "/" + gz_file_name, io.BytesIO(gz_file_obj.read()), sample_rate, gz_file_extension, max_records)
 
     raise Exception('"{}" file has some error(s)'.format(s3_path))
 
-#pylint: disable=global-statement
-def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
+#pylint: disable=global-statement,too-many-arguments
+def sample_file(table_spec, s3_path, file_handle, sample_rate, extension, max_records=1000):
     global skipped_files_count
 
     # Check whether file is without extension or not
@@ -460,7 +477,7 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
             skipped_files_count = skipped_files_count + 1
         return csv_records
     if extension == "gz":
-        return sampling_gz_file(table_spec, s3_path, file_handle, sample_rate)
+        return sampling_gz_file(table_spec, s3_path, file_handle, sample_rate, max_records)
     if extension == "jsonl":
         # If file object read from s3 bucket file else use extracted file object from zip or gz
         file_handle = file_handle._raw_stream if hasattr(file_handle, "_raw_stream") else file_handle
@@ -478,12 +495,7 @@ def sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
         return records
 
     if extension == "parquet":
-        iterator = parquet.get_row_iterator(file_handle)
-        if iterator is not None:
-            return get_records_for_iterator(s3_path, sample_rate, iterator)
-        LOGGER.warning('Skipping "%s" file as it is empty',s3_path)
-        skipped_files_count = skipped_files_count + 1
-        return []
+        return get_records_for_parquet(s3_path, sample_rate, max_records, file_handle)
 
     if extension == "avro":
         iterator = avro.get_row_iterator(file_handle)
@@ -585,7 +597,7 @@ def sample_files(config, table_spec, s3_files,
                     max_records,
                     sample_rate)
         try:
-            yield from itertools.islice(sample_file(table_spec, s3_path, file_handle, sample_rate, extension), max_records)
+            yield from itertools.islice(sample_file(table_spec, s3_path, file_handle, sample_rate, extension, max_records), max_records)
         except (UnicodeDecodeError,json.decoder.JSONDecodeError):
             # UnicodeDecodeError will be raised if non csv file parsed to csv parser
             # JSONDecodeError will be reaised if non JSONL file parsed to JSON parser

--- a/tests/unittests/test_comporessed_file.py
+++ b/tests/unittests/test_comporessed_file.py
@@ -243,7 +243,7 @@ class TestUnsupportedFiles(unittest.TestCase):
 
             return [{'s3_path': 'unittest_compressed_files/gz_stored_as_csv.csv', 'file_handle': file_handle, 'extension': 'csv'}]
 
-    def mock_csv_sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
+    def mock_csv_sample_file(table_spec, s3_path, file_handle, sample_rate, extension, max_records=1000):
         raise UnicodeDecodeError("test",b"'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte",42, 43, 'the universe and everything else')
 
     def mock_get_files_to_sample_jsonl(config, s3_files, max_files):
@@ -255,7 +255,7 @@ class TestUnsupportedFiles(unittest.TestCase):
 
             return [{'s3_path': 'unittest_compressed_files/gz_stored_as_jsonl.jsonl', 'file_handle': file_handle, 'extension': 'jsonl'}]
 
-    def mock_jsonl_sample_file(table_spec, s3_path, file_handle, sample_rate, extension):
+    def mock_jsonl_sample_file(table_spec, s3_path, file_handle, sample_rate, extension, max_records=1000):
         # To raise json decoder error.
         return json.loads(b"'{'}")
 

--- a/tests/unittests/test_parquet_sampling.py
+++ b/tests/unittests/test_parquet_sampling.py
@@ -1,3 +1,5 @@
+import gzip
+import io
 import unittest
 import tempfile
 from unittest import mock
@@ -18,6 +20,22 @@ def make_parquet_file(num_rows, row_group_size, compression='snappy'):
     pq.write_table(table, parquet_file, row_group_size=row_group_size, compression=compression)
     parquet_file.seek(0)
     return parquet_file
+
+
+def make_gz_wrapped_parquet_file(num_rows, row_group_size, compression='snappy'):
+    # Mirrors how sampling_gz_file() expects its input: a file-like object
+    # containing the raw (still-compressed) gzip bytes, with the original
+    # filename embedded in the gzip header so utils.get_file_name_from_gzfile()
+    # can recover the ".parquet" extension.
+    raw_parquet_file = make_parquet_file(num_rows, row_group_size, compression)
+    raw_parquet_bytes = raw_parquet_file.read()
+    raw_parquet_file.close()
+
+    gz_file = tempfile.TemporaryFile('w+b')
+    with gzip.GzipFile(filename='data.parquet', mode='wb', fileobj=gz_file) as gz:
+        gz.write(raw_parquet_bytes)
+    gz_file.seek(0)
+    return gz_file
 
 
 class TestGetRecordsForParquet(unittest.TestCase):
@@ -101,3 +119,16 @@ class TestGetRecordsForParquet(unittest.TestCase):
         records = list(s3.sample_file({}, "s3://bucket/file.parquet", self.parquet_file, sample_rate=5, extension="parquet", max_records=1000))
 
         self.assertEqual([r['id'] for r in records], list(range(1, 101, 5)))
+
+    def test_max_records_is_respected_for_a_gz_wrapped_parquet_file(self):
+        # sampling_gz_file() forwards max_records through to the recursive
+        # sample_file() call on the decompressed inner file. This proves
+        # that forwarding actually has an effect: a gz-wrapped Parquet file
+        # honors the caller's max_records instead of silently falling back
+        # to the hardcoded default.
+        self.parquet_file = make_gz_wrapped_parquet_file(num_rows=100, row_group_size=10)
+
+        records = list(s3.sample_file(
+            {}, "s3://bucket/file.gz", self.parquet_file, sample_rate=1, extension="gz", max_records=5))
+
+        self.assertEqual([r['id'] for r in records], [1, 2, 3, 4, 5])

--- a/tests/unittests/test_parquet_sampling.py
+++ b/tests/unittests/test_parquet_sampling.py
@@ -1,0 +1,103 @@
+import unittest
+import tempfile
+from unittest import mock
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from tap_s3_csv import s3
+
+
+def make_parquet_file(num_rows, row_group_size, compression='snappy'):
+    parquet_file = tempfile.TemporaryFile('w+b')
+    data = {
+        "id": list(range(1, num_rows + 1)),
+        "name": [f"user_{i}" for i in range(1, num_rows + 1)],
+    }
+    table = pa.table(data)
+    pq.write_table(table, parquet_file, row_group_size=row_group_size, compression=compression)
+    parquet_file.seek(0)
+    return parquet_file
+
+
+class TestGetRecordsForParquet(unittest.TestCase):
+    """
+    Confirms the tap's Parquet sampling is wired up to
+    singer_encodings.parquet.sample_row_iterator() (which filters rows
+    before converting them to Python objects) instead of the old
+    get_row_iterator() + post-hoc filtering approach, and that logging
+    behavior is preserved.
+    """
+
+    def tearDown(self):
+        self.parquet_file.close()
+
+    def test_samples_rows_at_the_configured_rate(self):
+        # 10 row groups of 10 rows each.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        records = list(s3.get_records_for_parquet(
+            "s3://bucket/file.parquet", sample_rate=10, max_records=1000, file_handle=self.parquet_file))
+
+        self.assertEqual([r['id'] for r in records], list(range(1, 101, 10)))
+
+    def test_stops_early_without_reading_every_row_group(self):
+        # 10 row groups of 10 rows each; asking for only 3 sampled rows at
+        # sample_rate=1 should mean only the first row group ever gets
+        # decompressed via read_row_group.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+        original_read_row_group = pq.ParquetFile.read_row_group
+
+        with mock.patch.object(pq.ParquetFile, 'read_row_group', autospec=True) as mocked_read:
+            mocked_read.side_effect = original_read_row_group
+            records = list(s3.get_records_for_parquet(
+                "s3://bucket/file.parquet", sample_rate=1, max_records=3, file_handle=self.parquet_file))
+
+        self.assertEqual([r['id'] for r in records], [1, 2, 3])
+        self.assertEqual(mocked_read.call_count, 1)
+
+    @mock.patch("tap_s3_csv.s3.LOGGER")
+    def test_logs_progress_every_200_sampled_rows(self, mocked_logger):
+        self.parquet_file = make_parquet_file(num_rows=500, row_group_size=50)
+
+        records = list(s3.get_records_for_parquet(
+            "s3://bucket/file.parquet", sample_rate=1, max_records=1000, file_handle=self.parquet_file))
+
+        self.assertEqual(len(records), 500)
+        mocked_logger.info.assert_any_call("Sampled %s rows from %s", 200, "s3://bucket/file.parquet")
+        mocked_logger.info.assert_any_call("Sampled %s rows from %s", 400, "s3://bucket/file.parquet")
+        # Final summary log after the loop completes.
+        mocked_logger.info.assert_any_call("Sampled %s rows from %s", 500, "s3://bucket/file.parquet")
+
+    def test_sample_file_dispatches_parquet_extension_to_get_records_for_parquet(self):
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        records = list(s3.sample_file({}, "s3://bucket/file.parquet", self.parquet_file, sample_rate=5, extension="parquet", max_records=1000))
+
+        self.assertEqual([r['id'] for r in records], list(range(1, 101, 5)))
+
+    @mock.patch("tap_s3_csv.s3.LOGGER")
+    def test_sample_file_warns_and_skips_an_empty_parquet_file(self, mocked_logger):
+        self.parquet_file = make_parquet_file(num_rows=0, row_group_size=None)
+        skipped_before = s3.skipped_files_count
+
+        records = list(s3.sample_file({}, "s3://bucket/empty.parquet", self.parquet_file, sample_rate=5, extension="parquet", max_records=1000))
+
+        self.assertEqual(records, [])
+        mocked_logger.warning.assert_any_call('Skipping "%s" file as it is empty', "s3://bucket/empty.parquet")
+        self.assertEqual(s3.skipped_files_count, skipped_before + 1)
+
+    def test_samples_a_snappy_compressed_parquet_file(self):
+        # Snappy is pyarrow's default Parquet compression codec, so every
+        # other test in this file already exercises it implicitly. This
+        # test makes that coverage explicit end-to-end through the tap's
+        # sample_file() dispatch, and confirms the codec really is SNAPPY.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10, compression='snappy')
+
+        pf = pq.ParquetFile(self.parquet_file)
+        self.assertEqual(pf.metadata.row_group(0).column(0).compression, 'SNAPPY')
+        self.parquet_file.seek(0)
+
+        records = list(s3.sample_file({}, "s3://bucket/file.parquet", self.parquet_file, sample_rate=5, extension="parquet", max_records=1000))
+
+        self.assertEqual([r['id'] for r in records], list(range(1, 101, 5)))

--- a/tests/unittests/test_sample_files_file_handle_cleanup.py
+++ b/tests/unittests/test_sample_files_file_handle_cleanup.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest import mock
+from tap_s3_csv import s3
+
+
+def mock_sample_file_success(table_spec, s3_path, file_handle, sample_rate, extension):
+    yield {'id': 1}
+
+
+def mock_sample_file_raises_unicode_error(table_spec, s3_path, file_handle, sample_rate, extension):
+    raise UnicodeDecodeError('utf-8', b'', 0, 1, 'bad byte')
+
+
+class TestSampleFilesClosesFileHandles(unittest.TestCase):
+    """
+    sample_files() should always close each file's handle once it is done
+    sampling that file, regardless of whether sampling succeeded or raised
+    a (handled) parsing error. get_files_to_sample() returns every handle in
+    a single list that is kept alive for the whole generator's lifetime, so
+    relying on reference counting alone does not release handles as each
+    file finishes - sample_files() must close them explicitly.
+    """
+
+    @mock.patch("tap_s3_csv.s3.sample_file", side_effect=mock_sample_file_success)
+    @mock.patch("tap_s3_csv.s3.get_files_to_sample")
+    def test_closes_handle_after_successful_sampling(self, mock_get_files_to_sample, mock_sample_file):
+        mock_handle_1 = mock.Mock()
+        mock_handle_2 = mock.Mock()
+        mock_get_files_to_sample.return_value = [
+            {"s3_path": "file1.csv", "file_handle": mock_handle_1, "extension": "csv"},
+            {"s3_path": "file2.csv", "file_handle": mock_handle_2, "extension": "csv"},
+        ]
+
+        list(s3.sample_files({}, {}, [], max_files=2))
+
+        mock_handle_1.close.assert_called_once()
+        mock_handle_2.close.assert_called_once()
+
+    @mock.patch("tap_s3_csv.s3.sample_file", side_effect=mock_sample_file_raises_unicode_error)
+    @mock.patch("tap_s3_csv.s3.get_files_to_sample")
+    def test_closes_handle_even_when_sampling_raises_handled_error(self, mock_get_files_to_sample, mock_sample_file):
+        mock_handle = mock.Mock()
+        mock_get_files_to_sample.return_value = [
+            {"s3_path": "bad_file.csv", "file_handle": mock_handle, "extension": "csv"},
+        ]
+
+        list(s3.sample_files({}, {}, [], max_files=1))
+
+        mock_handle.close.assert_called_once()
+
+    @mock.patch("tap_s3_csv.s3.sample_file", side_effect=mock_sample_file_success)
+    @mock.patch("tap_s3_csv.s3.get_files_to_sample")
+    def test_does_not_raise_when_handle_has_no_close(self, mock_get_files_to_sample, mock_sample_file):
+        # file_handle objects without a close() method (e.g. plain values used
+        # in some test doubles) should not cause sample_files() to error out.
+        mock_get_files_to_sample.return_value = [
+            {"s3_path": "file1.csv", "file_handle": object(), "extension": "csv"},
+        ]
+
+        # Should not raise
+        result = list(s3.sample_files({}, {}, [], max_files=1))
+        self.assertEqual(result, [{'id': 1}])
+
+    @mock.patch("tap_s3_csv.s3.sample_file", side_effect=mock_sample_file_success)
+    @mock.patch("tap_s3_csv.s3.get_files_to_sample")
+    def test_does_not_raise_when_close_itself_raises(self, mock_get_files_to_sample, mock_sample_file):
+        mock_handle = mock.Mock()
+        mock_handle.close.side_effect = OSError("connection already closed")
+        mock_get_files_to_sample.return_value = [
+            {"s3_path": "file1.csv", "file_handle": mock_handle, "extension": "csv"},
+        ]
+
+        # Should not raise even though close() itself errors
+        result = list(s3.sample_files({}, {}, [], max_files=1))
+        self.assertEqual(result, [{'id': 1}])
+        mock_handle.close.assert_called_once()

--- a/tests/unittests/test_sample_files_file_handle_cleanup.py
+++ b/tests/unittests/test_sample_files_file_handle_cleanup.py
@@ -3,11 +3,11 @@ from unittest import mock
 from tap_s3_csv import s3
 
 
-def mock_sample_file_success(table_spec, s3_path, file_handle, sample_rate, extension):
+def mock_sample_file_success(table_spec, s3_path, file_handle, sample_rate, extension, max_records=1000):
     yield {'id': 1}
 
 
-def mock_sample_file_raises_unicode_error(table_spec, s3_path, file_handle, sample_rate, extension):
+def mock_sample_file_raises_unicode_error(table_spec, s3_path, file_handle, sample_rate, extension, max_records=1000):
     raise UnicodeDecodeError('utf-8', b'', 0, 1, 'bad byte')
 
 


### PR DESCRIPTION
# Description of change
Fixes two memory issues in schema discovery:
- File handles for sampled files weren't explicitly closed, leaving read-ahead buffers/connections open longer than needed.
- Parquet sampling converted an entire row group to Python objects before filtering by sample_rate, so files with large row groups could spike memory well beyond what a sample actually needs.

Bumps singer-encodings to 0.6.0, which adds `sample_row_iterator()` (filters at the Arrow level before converting to Python objects) and `is_empty()` (checks for empty files via footer metadata only, no decompression).

# Manual QA steps
 - pytest tests/unittests
 - Verified against synthetic Snappy Parquet files sized/shaped like the customer's file (single large row group and multiple moderate row groups) - memory growth dropped substantially in both cases
 - tested parquet file sync in int environment
 
# Risks
 - Low - new sampling path is only used for discovery, not full syncs; get_row_iterator() (used during sync) is unchanged
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
