### PR TITLE
Fix OOM errors when syncing Parquet files with large row groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.1
+  * Bump singer-encodings to 0.6.1 for memory-efficient Parquet row group decoding [#93](https://github.com/singer-io/tap-s3-csv/pull/93)
+
 ## 2.3.0
   * Close file handles after sampling, and reduce Parquet discovery memory usage by sampling rows before converting them to Python objects [#92](https://github.com/singer-io/tap-s3-csv/pull/92)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-s3-csv',
-      version='2.3.0',
+      version='2.3.1',
       description='Singer.io tap for extracting CSV files from S3',
       author='Stitch',
       url='https://singer.io',
@@ -13,7 +13,7 @@ setup(name='tap-s3-csv',
           'backoff==1.10.0',
           'boto3==1.39.8',
           'urllib3==2.7.0',
-          'singer-encodings==0.6.0',
+          'singer-encodings==0.6.1',
           'singer-python==5.19.0',
           'voluptuous==0.15.2',
           's3fs==2025.9.0'


### PR DESCRIPTION
# Description of change
Bumps singer-encodings to 0.6.1, which changes Parquet file reading to use bounded batches (batch_size=65536) instead of loading entire row groups into memory at once. This prevents OOM kills on files with large or few row groups.

# Manual QA steps
 - tested in int environment
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
